### PR TITLE
Fix file permissions in workflow after sudo build

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           sudo ./bin/build-appliance.sh ${{ matrix.appliance }} ${{ matrix.arch }}
 
+          # Fix ownership of build directory so we can work with the files
+          sudo chown -R $USER:$USER .build
+
       - name: Prepare image files for release
         id: metadata
         run: |


### PR DESCRIPTION
## Problem

After the build step runs with `sudo`, all files in `.build/` are owned by root. The next step tries to copy these files without sudo and gets 'Permission denied'.

## Solution

Added `sudo chown -R $USER:$USER .build` after the build step to fix ownership of the build directory.

## Testing

This will allow the 'Prepare image files for release' step to successfully copy and rename the image files.