### PR TITLE
Fix registry merging and add debug output

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -166,9 +166,12 @@ jobs:
           mkdir -p merged-registry/streams/v1
           mkdir -p merged-registry/images
 
-          # Initialize empty registry if needed
-          if [ ! -f "merged-registry/streams/v1/index.json" ]; then
-            cat > merged-registry/streams/v1/index.json <<'INDEXEOF'
+          # List what we downloaded
+          echo "==> Downloaded artifacts:"
+          ls -la registries/
+
+          # Initialize index.json
+          cat > merged-registry/streams/v1/index.json <<'INDEXEOF'
           {
             "index": {
               "images": {
@@ -180,16 +183,24 @@ jobs:
             "format": "index:1.0"
           }
           INDEXEOF
-          fi
 
           # Merge all registry artifacts
           for reg_dir in registries/registry-*; do
+            echo "==> Processing $reg_dir"
+            ls -la "$reg_dir" || true
+
+            # Handle both nested and flat structures
             if [ -d "$reg_dir/registry" ]; then
-              echo "==> Merging $reg_dir"
-              # Copy registry contents
+              echo "  Found nested registry structure"
               cp -r "$reg_dir/registry"/* merged-registry/ 2>/dev/null || true
+            elif [ -d "$reg_dir/streams" ]; then
+              echo "  Found flat registry structure"
+              cp -r "$reg_dir"/* merged-registry/ 2>/dev/null || true
             fi
           done
+
+          echo "==> Merged registry contents:"
+          find merged-registry -type f
 
       - name: Rewrite URLs to point to GitHub Releases
         env:


### PR DESCRIPTION
## Problem

The published registry is missing the  file, causing image launches to fail with "image couldn't be found".

## Changes

- Added debug output to see downloaded artifact structure
- Handle both nested () and flat registry structures when merging
- Show final merged registry contents for debugging

## Diagnosis

This will help identify why the registry files aren't being properly merged before deployment to GitHub Pages.