### PR TITLE
Fix URL rewriting to properly map image paths to release assets

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -213,22 +213,75 @@ jobs:
             cp "$IMAGES_JSON" "${IMAGES_JSON}.bak"
 
             # Rewrite paths to point to GitHub release assets
-            # Change paths like "images/FINGERPRINT/incus.tar.xz"
-            # to "https://github.com/REPO/releases/download/latest/APPLIANCE-ARCH-incus.tar.xz"
+            # The original paths are like "images/FINGERPRINT/incus.tar.xz" or "images/FINGERPRINT/rootfs.squashfs"
+            # We need to map them to the renamed release files: "APPLIANCE-ARCH-incus.tar.xz" or "APPLIANCE-ARCH-rootfs.squashfs"
 
             BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/latest"
 
-            # This is a simplified rewrite - a more sophisticated version would parse the JSON properly
-            # For now, we'll update the paths in the JSON to point to release URLs
+            # Extract appliance name from the first alias (e.g., "nginx" from "nginx/amd64")
+            # Then rewrite paths based on product metadata and file type
             jq --arg base_url "$BASE_URL" '
-              walk(
-                if type == "object" and has("path") then
-                  .path = ($base_url + "/" + (.ftype + ".tar.xz" | sub("lxd.tar.xz"; "incus.tar.xz")))
-                else
-                  .
-                end
+              .products |= with_entries(
+                .value.versions |= with_entries(
+                  .value.items |= with_entries(
+                    # Extract appliance name from first alias
+                    .value.path = (
+                      if .value.ftype == "incus.tar.xz" then
+                        $base_url + "/" + ((.value | getpath(["aliases"])) // "" | split(",")[0] | split("/")[0]) + "-" + (getpath(["products", .key, "arch"]) // "amd64") + "-incus.tar.xz"
+                      elif .value.ftype == "squashfs" then
+                        $base_url + "/" + ((.value | getpath(["aliases"])) // "" | split(",")[0] | split("/")[0]) + "-" + (getpath(["products", .key, "arch"]) // "amd64") + "-rootfs.squashfs"
+                      else
+                        .value.path
+                      end
+                    )
+                  )
+                )
               )
-            ' "${IMAGES_JSON}.bak" > "$IMAGES_JSON" || cp "${IMAGES_JSON}.bak" "$IMAGES_JSON"
+            ' "${IMAGES_JSON}.bak" > "$IMAGES_JSON.tmp"
+
+            # The above approach is complex. Let's use a simpler approach based on the product key structure
+            # Product key is like "alpine:3.20:default:amd64" and aliases contain "nginx,nginx/amd64"
+            jq --arg base_url "$BASE_URL" '
+              .products = (.products | to_entries | map(
+                .value.versions = (.value.versions | to_entries | map(
+                  # Get appliance name from first alias
+                  . as $version |
+                  (.value.items | to_entries | map(
+                    if .value.ftype == "incus.tar.xz" then
+                      .value.path = ($base_url + "/" + (($version.value.items | to_entries | map(select(.value.ftype == "incus.tar.xz")) | .[0].value.path | split("/") | last) | sub("^.*/"; "")))
+                    elif .value.ftype == "squashfs" then
+                      .value.path = ($base_url + "/" + (($version.value.items | to_entries | map(select(.value.ftype == "squashfs")) | .[0].value.path | split("/") | last) | sub("^.*/"; "")))
+                    else
+                      .
+                    end
+                  ) | from_entries) as $items |
+                  .value.items = $items |
+                  .
+                ) | from_entries) |
+                .
+              ) | from_entries)
+            ' "${IMAGES_JSON}.bak" > "$IMAGES_JSON.tmp2"
+
+            # Actually, the simplest approach: use the aliases field from the parent product
+            # Product structure: products -> {productkey} -> aliases (contains "nginx"), arch -> versions -> items
+            jq --arg base_url "$BASE_URL" '
+              .products |= with_entries(
+                # Get appliance name from aliases (first non-slash alias)
+                (.value.aliases | split(",") | map(select(contains("/") | not)) | .[0]) as $appliance |
+                .value.arch as $arch |
+                .value.versions |= with_entries(
+                  .value.items |= with_entries(
+                    if .value.ftype == "incus.tar.xz" then
+                      .value.path = ($base_url + "/" + $appliance + "-" + $arch + "-incus.tar.xz")
+                    elif .value.ftype == "squashfs" then
+                      .value.path = ($base_url + "/" + $appliance + "-" + $arch + "-rootfs.squashfs")
+                    else
+                      .
+                    end
+                  )
+                )
+              )
+            ' "${IMAGES_JSON}.bak" > "$IMAGES_JSON"
 
             echo "==> Registry URLs updated"
             echo "Sample paths:"


### PR DESCRIPTION
## Problem

The URL rewriting logic in the publish job was incorrectly constructing filenames, resulting in invalid URLs in `images.json`:
- `https://github.com/accuser/incus-appliance/releases/download/latest/incus.tar.xz.tar.xz`
- `https://github.com/accuser/incus-appliance/releases/download/latest/squashfs.tar.xz`

This caused `incus launch appliance:nginx` to fail with "The requested image couldn't be found".

## Solution

Updated the jq expression to:
1. Extract the appliance name from the `aliases` field (e.g., "nginx" from "nginx,nginx/amd64")
2. Use the `arch` field from the product metadata
3. Properly map file types:
   - `incus.tar.xz` → `nginx-amd64-incus.tar.xz`
   - `squashfs` → `nginx-amd64-rootfs.squashfs`

These filenames now match the renamed files created in the release step.

## Testing

After this PR merges, the registry should have correct URLs and `incus launch appliance:nginx` should work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)