### PR TITLE
Remove URL rewriting - serve images from GitHub Pages

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -202,47 +202,6 @@ jobs:
           echo "==> Merged registry contents:"
           find merged-registry -type f
 
-      - name: Rewrite URLs to point to GitHub Releases
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-        run: |
-          IMAGES_JSON="merged-registry/streams/v1/images.json"
-
-          if [ -f "$IMAGES_JSON" ]; then
-            # Backup original
-            cp "$IMAGES_JSON" "${IMAGES_JSON}.bak"
-
-            # Rewrite paths to point to GitHub release assets
-            # Original paths: "images/FINGERPRINT/incus.tar.xz" or "images/FINGERPRINT/rootfs.squashfs"
-            # Target paths: "APPLIANCE-ARCH-incus.tar.xz" or "APPLIANCE-ARCH-rootfs.squashfs"
-
-            BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/latest"
-
-            # Extract appliance name from aliases (first alias without a slash, e.g., "nginx")
-            # Product structure: products -> {key} -> aliases, arch, versions -> items
-            jq --arg base_url "$BASE_URL" '
-              .products |= with_entries(
-                (.value.aliases | split(",") | map(select(contains("/") | not)) | .[0]) as $appliance |
-                .value.arch as $arch |
-                .value.versions |= with_entries(
-                  .value.items |= with_entries(
-                    if .value.ftype == "incus.tar.xz" then
-                      .value.path = ($base_url + "/" + $appliance + "-" + $arch + "-incus.tar.xz")
-                    elif .value.ftype == "squashfs" then
-                      .value.path = ($base_url + "/" + $appliance + "-" + $arch + "-rootfs.squashfs")
-                    else
-                      .
-                    end
-                  )
-                )
-              )
-            ' "${IMAGES_JSON}.bak" > "$IMAGES_JSON"
-
-            echo "==> Registry URLs updated"
-            echo "Sample paths:"
-            jq -r '.. | .path? // empty' "$IMAGES_JSON" | head -5
-          fi
-
       - name: Create index.html
         run: |
           cat > merged-registry/index.html <<'EOF'


### PR DESCRIPTION
## Problem

SimpleStreams clients like Incus concatenate the base URL with the `path` field from `images.json`. When we set absolute URLs like `https://github.com/.../releases/download/latest/...`, the client was producing:

```
https://accuser.github.io/incus-appliance/https:/github.com/accuser/incus-appliance/releases/download/latest/nginx-amd64-incus.tar.xz
```

## Solution

Since the image files are already being copied to the merged registry and uploaded to GitHub Pages, we can simply use the original relative paths. This removes the URL rewriting step entirely.

**Images are now served from GitHub Pages** alongside the metadata JSON files using the original paths like `images/FINGERPRINT/incus.tar.xz`.

The release job is kept as an alternative download location.

## Note on Limitations

GitHub Pages has:
- 100MB per file limit
- 1GB repository limit  
- 10GB/month bandwidth limit

For the nginx appliance (~5MB), this is fine. Larger appliances may need a different hosting solution in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)