### PR TITLE
Fix nginx appliance networking for OpenRC

### DIFF
--- a/appliances/nginx/image.yaml
+++ b/appliances/nginx/image.yaml
@@ -18,6 +18,7 @@ packages:
     - packages:
         - nginx
         - openrc
+        - ifupdown-ng
         - ca-certificates
         - curl
         - tzdata
@@ -38,6 +39,16 @@ files:
   - path: /usr/share/nginx/html/index.html
     generator: copy
     source: files/index.html
+    mode: "0644"
+
+  - path: /etc/network/interfaces
+    generator: dump
+    content: |-
+      auto lo
+      iface lo inet loopback
+
+      auto eth0
+      iface eth0 inet dhcp
     mode: "0644"
 
   - path: /etc/motd


### PR DESCRIPTION
## Problem

The nginx service fails to start because it depends on networking, which requires:
1. `/etc/network/interfaces` file (missing in Alpine minirootfs)
2. `ifupdown-ng` package for the `ifquery` command

Error when trying to start nginx:
```
ifquery: could not parse /etc/network/interfaces
ERROR: networking failed to start
ERROR: cannot start nginx as networking would not start
```

## Solution

- Add `/etc/network/interfaces` with loopback and eth0 DHCP configuration
- Add `ifupdown-ng` package to the image

## Testing

After this PR merges and the image rebuilds:
```bash
incus delete -f my-nginx 2>/dev/null || true
incus image delete appliance:nginx 2>/dev/null || true
incus launch appliance:nginx my-nginx
incus exec my-nginx -- rc-service nginx status
incus exec my-nginx -- curl -s localhost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)