### PR TITLE
Enable arm64 builds in CI workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         appliance: [nginx]  # Add more appliances as they're created
-        arch: [amd64]       # Add arm64 when needed
+        arch: [amd64, arm64]
       fail-fast: false
 
     steps:
@@ -142,7 +142,7 @@ jobs:
 
             ### Available Appliances
 
-            - nginx (amd64)
+            - nginx (amd64, arm64)
 
   publish:
     needs: build
@@ -227,7 +227,7 @@ jobs:
 
             <h2>Available Appliances</h2>
             <ul>
-              <li>nginx - Reverse proxy and web server (Alpine 3.20, ~50MB)</li>
+              <li>nginx - Reverse proxy and web server (Alpine 3.20, amd64/arm64, ~50MB)</li>
             </ul>
 
             <h2>Documentation</h2>


### PR DESCRIPTION
## Summary

- Add arm64 to the build matrix for multi-architecture support
- Update release notes and landing page to reflect both architectures

## Changes

- Build matrix now runs for both `amd64` and `arm64`
- Release notes updated to show `nginx (amd64, arm64)`
- Landing page shows architecture support

## Notes

`distrobuilder` supports cross-architecture builds via QEMU emulation, so arm64 images can be built on the amd64 GitHub runners. Build times for arm64 may be longer due to emulation.

## Test plan

- [ ] Workflow runs successfully
- [ ] Both amd64 and arm64 images are built
- [ ] Registry contains both architecture variants
- [ ] Images can be launched on respective architectures

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)