### PR TITLE
Add caching for distrobuilder base images

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache distrobuilder base images
+        uses: actions/cache@v4
+        with:
+          path: .cache/distrobuilder
+          key: distrobuilder-${{ matrix.appliance }}-${{ matrix.arch }}-${{ hashFiles(format('appliances/{0}/image.yaml', matrix.appliance)) }}
+          restore-keys: |
+            distrobuilder-${{ matrix.appliance }}-${{ matrix.arch }}-
+            distrobuilder-${{ matrix.appliance }}-
+            distrobuilder-
+
+      - name: Prepare cache directory
+        run: |
+          # Create cache directory if it doesn't exist
+          mkdir -p .cache/distrobuilder
+          # Ensure distrobuilder can write to cache (runs as root)
+          sudo chown -R root:root .cache/distrobuilder 2>/dev/null || true
+
       - name: Install build dependencies
         run: |
           # Add Zabbly repository for Incus tools
@@ -49,8 +66,9 @@ jobs:
         run: |
           sudo ./bin/build-appliance.sh ${{ matrix.appliance }} ${{ matrix.arch }}
 
-          # Fix ownership of build directory so we can work with the files
+          # Fix ownership so we can work with the files and cache can be saved
           sudo chown -R $USER:$USER .build
+          sudo chown -R $USER:$USER .cache/distrobuilder
 
       - name: Prepare image files for release
         id: metadata


### PR DESCRIPTION
## Summary

Cache the `.cache/distrobuilder` directory between CI runs to speed up builds and reduce network failures.

## Changes

- Add `actions/cache@v4` step to cache base images
- Handle ownership changes (cache restored as user, distrobuilder runs as root)
- Cache key invalidates when `image.yaml` changes (e.g., Alpine version bump)

## Cache Key Strategy

```
distrobuilder-{appliance}-{arch}-{hash of image.yaml}
```

Restore keys allow partial cache hits:
1. Same appliance + arch (different image.yaml hash)
2. Same appliance (different arch)
3. Any distrobuilder cache

## Expected Impact

- **Build time**: Reduced by 1-2 minutes (skip ~50-100MB download)
- **Reliability**: Fewer transient network failures
- **Bandwidth**: Reduced load on Alpine mirrors

## Test plan

- [ ] First run: Cache miss, downloads base image, saves cache
- [ ] Second run: Cache hit, skips download
- [ ] After image.yaml change: Cache miss (new key), downloads new version

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)