### PR TITLE
Fix arm64 builds by adding QEMU binfmt support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -45,6 +45,12 @@ jobs:
           # Ensure distrobuilder can write to cache (runs as root)
           sudo chown -R root:root .cache/distrobuilder 2>/dev/null || true
 
+      - name: Set up QEMU for cross-architecture builds
+        if: matrix.arch != 'amd64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.arch }}
+
       - name: Install build dependencies
         run: |
           # Add Zabbly repository for Incus tools


### PR DESCRIPTION
## Summary

Fix the arm64 build failures by setting up QEMU user-mode emulation.

## Problem

The arm64 builds were failing with:
```
Error: Failed to run post-unpack: fork/exec /proc/self/fd/7: exec format error
```

This happens because the GitHub runner (amd64) cannot execute arm64 binaries natively. distrobuilder needs to run shell scripts inside the arm64 rootfs during the build process.

## Solution

Add `docker/setup-qemu-action@v3` to register QEMU binfmt handlers. This enables transparent execution of arm64 binaries on the amd64 runner.

The step only runs when `matrix.arch != 'amd64'` to avoid unnecessary setup overhead for native builds.

## Test plan

- [ ] arm64 build completes successfully
- [ ] amd64 build still works (no QEMU overhead)
- [ ] Both images published to registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)