### PR TITLE
Fix cache directory chown error

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -74,7 +74,10 @@ jobs:
 
           # Fix ownership so we can work with the files and cache can be saved
           sudo chown -R $USER:$USER .build
-          sudo chown -R $USER:$USER .cache/distrobuilder
+          # Cache directory may not exist if distrobuilder cleaned it up
+          if [ -d .cache/distrobuilder ]; then
+            sudo chown -R $USER:$USER .cache/distrobuilder
+          fi
 
       - name: Prepare image files for release
         id: metadata


### PR DESCRIPTION
## Summary

Fix the build failure caused by trying to chown a non-existent cache directory.

## Problem

The build was failing with:
```
chown: cannot access '.cache/distrobuilder': No such file or directory
```

This happened because distrobuilder removes its cache directory after a successful build (note the log message "Removing cache directory").

## Solution

Make the chown conditional on the directory existing.

## Note

The caching added in #35 may not be effective since distrobuilder cleans up after itself. However, the builds are completing successfully - this fix just prevents the spurious error at the end.

We may need to investigate distrobuilder's `--keep-cache` option or similar if we want caching to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)