### PR TITLE
Migrate nginx appliance to Debian with cloud-init support

### DIFF
--- a/appliances/_base/debian.yaml
+++ b/appliances/_base/debian.yaml
@@ -1,5 +1,11 @@
 # Base configuration fragment for Debian appliances
 # Include this in your appliance with YAML anchors or copy relevant sections
+#
+# This base provides:
+# - Debian Bookworm (12) minimal installation
+# - cloud-init for last-mile configuration
+# - systemd for service management
+# - Common utilities for networking and TLS
 
 image:
   distribution: debian
@@ -15,18 +21,18 @@ packages:
   update: true
   cleanup: true
 
-# Common packages for most appliances
-common_packages:
+# Essential packages for all appliances
+base_packages:
   - ca-certificates
   - curl
   - gnupg
-  - apt-transport-https
   - tzdata
   - logrotate
-
-# For services
-service_packages:
+  # cloud-init for last-mile configuration
+  - cloud-init
+  # systemd and dbus for service management
   - systemd
+  - systemd-sysv
   - dbus
 
 # For networking
@@ -34,10 +40,28 @@ network_packages:
   - iproute2
   - iputils-ping
   - dnsutils
-  - netcat-openbsd
 
 # Common actions
 common_actions:
+  configure_cloud_init:
+    trigger: post-packages
+    action: |-
+      # Configure cloud-init for Incus/LXD
+      # Use the LXD datasource (compatible with Incus)
+      cat > /etc/cloud/cloud.cfg.d/99-incus.cfg <<'CLOUDCFG'
+      # Incus/LXD datasource configuration
+      datasource_list: [LXD]
+      datasource:
+        LXD:
+          apply_network_config: true
+      CLOUDCFG
+
+      # Ensure cloud-init services are enabled
+      systemctl enable cloud-init-local.service
+      systemctl enable cloud-init.service
+      systemctl enable cloud-config.service
+      systemctl enable cloud-final.service
+
   cleanup:
     trigger: post-packages
     action: |-
@@ -47,9 +71,9 @@ common_actions:
       rm -rf /tmp/*
       rm -rf /var/tmp/*
 
-  disable_services:
+  disable_unnecessary_services:
     trigger: post-packages
     action: |-
-      # Disable unnecessary services
+      # Disable unnecessary services for containers
       systemctl disable apt-daily.timer || true
       systemctl disable apt-daily-upgrade.timer || true

--- a/appliances/nginx/README.md
+++ b/appliances/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx Appliance
 
-A lightweight, production-ready Nginx reverse proxy and web server appliance based on Alpine Linux.
+A production-ready Nginx reverse proxy and web server appliance based on Debian with cloud-init support for automated configuration.
 
 ## Quick Start
 
@@ -17,13 +17,102 @@ incus exec my-proxy -- curl -s localhost
 
 ## Features
 
-- **Minimal footprint**: Alpine Linux base (~50MB)
+- **Debian-based**: Stable Debian Bookworm with broad compatibility
+- **cloud-init support**: Automated last-mile configuration
 - **Production-ready**: Optimized configuration with gzip, security headers
 - **Health endpoint**: Built-in `/health` endpoint for monitoring
 - **Log rotation**: Automatic log rotation configured
 - **Easy configuration**: Drop configs in `/etc/nginx/conf.d/`
 
-## Configuration
+## Cloud-Init Configuration
+
+This appliance supports cloud-init for automated configuration at launch time.
+
+### Basic Example
+
+```bash
+# Create instance without starting
+incus init appliance:nginx my-proxy
+
+# Configure via cloud-init
+incus config set my-proxy cloud-init.user-data - << 'EOF'
+#cloud-config
+write_files:
+  - path: /etc/nginx/conf.d/mysite.conf
+    content: |
+      server {
+        listen 80;
+        server_name example.com;
+        location / {
+          proxy_pass http://backend:8080;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+        }
+      }
+
+runcmd:
+  - nginx -t
+  - systemctl reload nginx
+EOF
+
+# Start the instance
+incus start my-proxy
+```
+
+### Advanced Example with SSL
+
+```bash
+incus init appliance:nginx my-proxy
+
+incus config set my-proxy cloud-init.user-data - << 'EOF'
+#cloud-config
+packages:
+  - certbot
+  - python3-certbot-nginx
+
+write_files:
+  - path: /etc/nginx/conf.d/mysite.conf
+    content: |
+      server {
+        listen 80;
+        server_name example.com;
+        root /var/www/html;
+
+        location /.well-known/acme-challenge/ {
+          root /var/www/html;
+        }
+
+        location / {
+          return 301 https://$host$request_uri;
+        }
+      }
+
+runcmd:
+  - mkdir -p /var/www/html
+  - nginx -t && systemctl reload nginx
+  # Uncomment after DNS is configured:
+  # - certbot --nginx -d example.com --non-interactive --agree-tos -m admin@example.com
+EOF
+
+incus start my-proxy
+```
+
+### Network Configuration
+
+```bash
+incus config set my-proxy cloud-init.network-config - << 'EOF'
+version: 2
+ethernets:
+  eth0:
+    addresses:
+      - 10.0.0.10/24
+    gateway4: 10.0.0.1
+    nameservers:
+      addresses: [8.8.8.8, 8.8.4.4]
+EOF
+```
+
+## Manual Configuration
 
 ### Adding a Site
 
@@ -48,7 +137,7 @@ Push it to the appliance:
 ```bash
 incus file push mysite.conf my-proxy/etc/nginx/conf.d/
 incus exec my-proxy -- nginx -t
-incus exec my-proxy -- nginx -s reload
+incus exec my-proxy -- systemctl reload nginx
 ```
 
 ### Editing Configuration
@@ -58,7 +147,7 @@ incus exec my-proxy -- nginx -s reload
 incus exec my-proxy -- vi /etc/nginx/conf.d/default.conf
 
 # Test and reload
-incus exec my-proxy -- nginx -t && nginx -s reload
+incus exec my-proxy -- nginx -t && systemctl reload nginx
 ```
 
 ## Networking
@@ -95,18 +184,21 @@ incus config device add my-proxy config disk source=nginx-config path=/etc/nginx
 
 ```bash
 # Install certbot inside the appliance
-incus exec my-proxy -- apk add certbot
+incus exec my-proxy -- apt-get update
+incus exec my-proxy -- apt-get install -y certbot python3-certbot-nginx
 
 # Obtain a certificate
-incus exec my-proxy -- certbot certonly --webroot -w /usr/share/nginx/html -d example.com
+incus exec my-proxy -- certbot --nginx -d example.com
 
-# Configure nginx to use the certificate
-incus exec my-proxy -- vi /etc/nginx/conf.d/ssl.conf
+# Auto-renewal is configured automatically
 ```
 
 ### Using External Certificates
 
 ```bash
+# Create SSL directory
+incus exec my-proxy -- mkdir -p /etc/nginx/ssl
+
 # Push certificates to the appliance
 incus file push cert.pem my-proxy/etc/nginx/ssl/cert.pem
 incus file push key.pem my-proxy/etc/nginx/ssl/key.pem
@@ -137,13 +229,10 @@ incus exec my-proxy -- tail -f /var/log/nginx/error.log
 incus exec my-proxy -- tail -f /var/log/nginx/*.log
 ```
 
-### Metrics
-
-Check connection and request metrics:
+### Service Status
 
 ```bash
-incus exec my-proxy -- sh -c 'ps aux | grep nginx'
-incus exec my-proxy -- sh -c 'netstat -an | grep :80'
+incus exec my-proxy -- systemctl status nginx
 ```
 
 ## Common Tasks
@@ -151,7 +240,7 @@ incus exec my-proxy -- sh -c 'netstat -an | grep :80'
 ### Reload Configuration
 
 ```bash
-incus exec my-proxy -- nginx -s reload
+incus exec my-proxy -- systemctl reload nginx
 ```
 
 ### Test Configuration
@@ -163,7 +252,7 @@ incus exec my-proxy -- nginx -t
 ### Restart Nginx
 
 ```bash
-incus exec my-proxy -- rc-service nginx restart
+incus exec my-proxy -- systemctl restart nginx
 ```
 
 ### View Version
@@ -188,21 +277,31 @@ incus exec my-proxy -- cat /var/log/nginx/error.log
 
 ```bash
 # Check service status
-incus exec my-proxy -- rc-service nginx status
+incus exec my-proxy -- systemctl status nginx
 
-# View system logs
-incus exec my-proxy -- dmesg | tail
+# View journal logs
+incus exec my-proxy -- journalctl -u nginx
+```
+
+### Cloud-Init Issues
+
+```bash
+# Check cloud-init status
+incus exec my-proxy -- cloud-init status
+
+# View cloud-init logs
+incus exec my-proxy -- cat /var/log/cloud-init-output.log
 ```
 
 ### Permission Issues
 
 ```bash
-# Check nginx user exists
-incus exec my-proxy -- id nginx
+# Check www-data user exists
+incus exec my-proxy -- id www-data
 
 # Fix permissions
-incus exec my-proxy -- chown -R nginx:nginx /var/log/nginx
-incus exec my-proxy -- chown -R nginx:nginx /var/cache/nginx
+incus exec my-proxy -- chown -R www-data:www-data /var/log/nginx
+incus exec my-proxy -- chown -R www-data:www-data /var/cache/nginx
 ```
 
 ## Resource Requirements

--- a/appliances/nginx/appliance.yaml
+++ b/appliances/nginx/appliance.yaml
@@ -1,7 +1,7 @@
 # appliance.yaml - Appliance metadata
 name: nginx
-version: "1.0.0"
-description: "Lightweight reverse proxy and web server appliance"
+version: "2.0.0"
+description: "Reverse proxy and web server appliance with cloud-init support"
 maintainer: "Incus Appliance Registry"
 
 # Supported architectures
@@ -15,8 +15,11 @@ types:
 
 # Base distribution
 base:
-  distribution: alpine
-  release: "3.20"
+  distribution: debian
+  release: bookworm
+
+# cloud-init support
+cloud_init: true
 
 # Resource requirements (informational)
 requirements:

--- a/appliances/nginx/image.yaml
+++ b/appliances/nginx/image.yaml
@@ -1,28 +1,37 @@
 # image.yaml - Distrobuilder template for nginx appliance
+# Base: Debian Bookworm with cloud-init support
 image:
-  distribution: alpine
-  release: "3.20"
-  description: "Nginx reverse proxy appliance"
+  distribution: debian
+  release: bookworm
+  description: "Nginx reverse proxy and web server appliance"
 
 source:
-  downloader: rootfs-http
-  url: https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-minirootfs-3.20.3-x86_64.tar.gz
-  keys:
-    - 0482D84022F52DF1C4E7CD43293ACD0907D9495A
+  downloader: debootstrap
+  url: http://deb.debian.org/debian
 
 packages:
-  manager: apk
+  manager: apt
   update: true
   cleanup: true
   sets:
     - packages:
-        - nginx
-        - openrc
-        - ifupdown-ng
+        # Base system
         - ca-certificates
         - curl
+        - gnupg
         - tzdata
         - logrotate
+        # cloud-init for last-mile configuration
+        - cloud-init
+        # systemd for service management
+        - systemd
+        - systemd-sysv
+        - dbus
+        # Networking
+        - iproute2
+        - iputils-ping
+        # Nginx
+        - nginx
       action: install
 
 files:
@@ -41,16 +50,6 @@ files:
     source: files/index.html
     mode: "0644"
 
-  - path: /etc/network/interfaces
-    generator: dump
-    content: |-
-      auto lo
-      iface lo inet loopback
-
-      auto eth0
-      iface eth0 inet dhcp
-    mode: "0644"
-
   - path: /etc/motd
     generator: dump
     content: |-
@@ -60,8 +59,11 @@ files:
       ╠══════════════════════════════════════════╣
       ║  Config: /etc/nginx/conf.d/              ║
       ║  Logs:   /var/log/nginx/                 ║
-      ║  Status: nginx -t && nginx -s reload     ║
+      ║  Status: nginx -t && systemctl reload nginx
       ╚══════════════════════════════════════════╝
+
+      Supports cloud-init for automated configuration.
+      See: incus config set <instance> cloud-init.user-data ...
     mode: "0644"
 
   - path: /etc/logrotate.d/nginx
@@ -74,12 +76,22 @@ files:
           compress
           delaycompress
           notifempty
-          create 0640 nginx nginx
+          create 0640 www-data adm
           sharedscripts
           postrotate
-              /usr/sbin/nginx -s reopen
+              systemctl reload nginx > /dev/null 2>&1 || true
           endscript
       }
+    mode: "0644"
+
+  - path: /etc/cloud/cloud.cfg.d/99-incus.cfg
+    generator: dump
+    content: |-
+      # Incus/LXD datasource configuration
+      datasource_list: [LXD]
+      datasource:
+        LXD:
+          apply_network_config: true
     mode: "0644"
 
 actions:
@@ -99,10 +111,17 @@ actions:
       set -eux
 
       # Enable nginx at boot
-      rc-update add nginx default
+      systemctl enable nginx
 
-      # Create nginx user if not exists
-      adduser -D -H -s /sbin/nologin nginx 2>/dev/null || true
+      # Enable cloud-init services
+      systemctl enable cloud-init-local.service
+      systemctl enable cloud-init.service
+      systemctl enable cloud-config.service
+      systemctl enable cloud-final.service
+
+      # Disable unnecessary services for containers
+      systemctl disable apt-daily.timer || true
+      systemctl disable apt-daily-upgrade.timer || true
 
   - trigger: post-files
     action: |-
@@ -112,11 +131,23 @@ actions:
       # Ensure nginx runtime directory exists for config test
       mkdir -p /run/nginx
 
+      # Update nginx.conf to use www-data user (Debian default)
+      sed -i 's/^user nginx;/user www-data;/' /etc/nginx/nginx.conf
+
+      # Update PID path for Debian
+      sed -i 's|/run/nginx/nginx.pid|/run/nginx.pid|' /etc/nginx/nginx.conf
+
       # Validate nginx configuration
       nginx -t
 
       # Set permissions
-      chown -R nginx:nginx /var/log/nginx
-      chown -R nginx:nginx /var/cache/nginx
+      chown -R www-data:www-data /var/log/nginx
+      chown -R www-data:www-data /var/cache/nginx
       chown -R root:root /etc/nginx
       chmod -R 755 /usr/share/nginx/html
+
+      # Clean up package cache
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+      rm -rf /tmp/*
+      rm -rf /var/tmp/*


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Migrates nginx appliance from Alpine Linux to Debian Bookworm with full cloud-init support.

### Changes

- Switch base OS from Alpine Linux to Debian Bookworm
- Add cloud-init for automated last-mile configuration
- Update service management from OpenRC to systemd
- Change nginx user from nginx to www-data (Debian default)
- Bump version to 2.0.0 (breaking change)
- Update base Debian template with cloud-init configuration
- Comprehensive documentation for cloud-init usage

### Why This Change

Alpine Linux has well-documented issues with cloud-init:
- Service startup order problems (networking starts before cloud-init)
- Complex setup that cannot be done with standard rc-update add
- Network configuration does not work properly with Incus

Debian provides:
- Native, reliable cloud-init support
- Standard systemd service management
- Broader package compatibility (glibc vs musl)

### Cloud-Init Usage

```bash
# Create instance without starting
incus init appliance:nginx my-proxy

# Configure via cloud-init
incus config set my-proxy cloud-init.user-data - << EOF
#cloud-config
write_files:
  - path: /etc/nginx/conf.d/mysite.conf
    content: |
      server { listen 80; proxy_pass http://backend:8080; }
runcmd:
  - systemctl reload nginx
EOF

# Start the instance
incus start my-proxy
```

## Test plan

- [ ] Build nginx appliance for amd64
- [ ] Build nginx appliance for arm64
- [ ] Verify nginx starts and serves default page
- [ ] Verify cloud-init configuration works
- [ ] Verify health endpoint responds

Generated with Claude Code