### PR TITLE
Fix nginx.conf to use Debian defaults directly

### DIFF
--- a/appliances/nginx/files/nginx.conf
+++ b/appliances/nginx/files/nginx.conf
@@ -1,9 +1,9 @@
 # nginx.conf - Main nginx configuration
 
-user nginx;
+user www-data;
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
-pid /run/nginx/nginx.pid;
+pid /run/nginx.pid;
 
 events {
     worker_connections 1024;

--- a/appliances/nginx/image.yaml
+++ b/appliances/nginx/image.yaml
@@ -128,15 +128,6 @@ actions:
       #!/bin/sh
       set -eux
 
-      # Ensure nginx runtime directory exists for config test
-      mkdir -p /run/nginx
-
-      # Update nginx.conf to use www-data user (Debian default)
-      sed -i 's/^user nginx;/user www-data;/' /etc/nginx/nginx.conf
-
-      # Update PID path for Debian
-      sed -i 's|/run/nginx/nginx.pid|/run/nginx.pid|' /etc/nginx/nginx.conf
-
       # Validate nginx configuration
       nginx -t
 


### PR DESCRIPTION
## Summary

- Update `nginx.conf` to use correct Debian defaults (`www-data` user, `/run/nginx.pid`)
- Remove unnecessary `sed` commands from post-files action

## Why

The source file now reflects what ends up in the image, making it easier to understand and less fragile than patching values at build time.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)