### PR TITLE
Clarify that _base/debian.yaml is a reference template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Incus client fetches and launches
 ### Directory Structure
 
 - **`appliances/`** — Appliance definitions (each in its own directory)
-  - **`_base/`** — Shared base templates (debian.yaml)
+  - **`_base/`** — Reference templates for copy-paste (debian.yaml) — not includable, just canonical examples
   - **`<name>/`** — Each appliance directory contains:
     - `appliance.yaml` — Metadata (optional but recommended)
     - `image.yaml` — Distrobuilder build template (required)

--- a/appliances/_base/debian.yaml
+++ b/appliances/_base/debian.yaml
@@ -1,11 +1,14 @@
-# Base configuration fragment for Debian appliances
-# Include this in your appliance with YAML anchors or copy relevant sections
+# Base configuration reference for Debian appliances
 #
-# This base provides:
+# NOTE: This file is a REFERENCE TEMPLATE, not an includable base.
+# Distrobuilder does not support cross-file YAML anchors.
+# Copy the relevant sections into your appliance's image.yaml.
+#
+# This reference provides canonical examples for:
 # - Debian Bookworm (12) minimal installation
 # - cloud-init for last-mile configuration
 # - systemd for service management
-# - Common utilities for networking and TLS
+# - Common packages and actions
 
 image:
   distribution: debian


### PR DESCRIPTION
## Summary

Clarifies that `appliances/_base/debian.yaml` is a reference template for copy-paste, not an includable base file.

## Why

Distrobuilder doesn't support cross-file YAML anchors, so the base template can only serve as documented reference. The previous comment suggested it could be "included with YAML anchors" which was misleading.

## Changes

- Update `appliances/_base/debian.yaml` header comment
- Update `CLAUDE.md` directory structure description

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)