### PR TITLE
Remove unnecessary gnupg package from nginx appliance

### DIFF
--- a/appliances/nginx/image.yaml
+++ b/appliances/nginx/image.yaml
@@ -18,7 +18,6 @@ packages:
         # Base system
         - ca-certificates
         - curl
-        - gnupg
         - tzdata
         - logrotate
         # cloud-init for last-mile configuration


### PR DESCRIPTION
## Summary

Removes `gnupg` from the nginx appliance package list - it's not needed.

## Why

gnupg was copied from the base template which includes it for adding third-party GPG keys. Since nginx uses standard Debian packages, this dependency is unnecessary bloat.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)