### PR TITLE
Fix MOTD box alignment in nginx appliance

### DIFF
--- a/appliances/nginx/image.yaml
+++ b/appliances/nginx/image.yaml
@@ -53,14 +53,14 @@ files:
   - path: /etc/motd
     generator: dump
     content: |-
-      ╔══════════════════════════════════════════╗
-      ║  Nginx Appliance                         ║
-      ║  Incus Appliance Registry                ║
-      ╠══════════════════════════════════════════╣
-      ║  Config: /etc/nginx/conf.d/              ║
-      ║  Logs:   /var/log/nginx/                 ║
-      ║  Status: nginx -t && systemctl reload nginx
-      ╚══════════════════════════════════════════╝
+      ╔══════════════════════════════════════════════════╗
+      ║  Nginx Appliance                                 ║
+      ║  Incus Appliance Registry                        ║
+      ╠══════════════════════════════════════════════════╣
+      ║  Config: /etc/nginx/conf.d/                      ║
+      ║  Logs:   /var/log/nginx/                         ║
+      ║  Status: nginx -t && systemctl reload nginx      ║
+      ╚══════════════════════════════════════════════════╝
 
       Supports cloud-init for automated configuration.
       See: incus config set <instance> cloud-init.user-data ...


### PR DESCRIPTION
## Summary

Fixes the broken ASCII box in the MOTD:
- Add missing closing `║` on Status line
- Widen box to accommodate the longer systemctl command
- Align all content with proper padding

## Before
```
║  Status: nginx -t && systemctl reload nginx
╚══════════════════════════════════════════╝
```

## After
```
║  Status: nginx -t && systemctl reload nginx      ║
╚══════════════════════════════════════════════════╝
```

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)