### PR TITLE
Remove broken cross-references to non-existent appliances

### DIFF
--- a/appliances/nginx/README.md
+++ b/appliances/nginx/README.md
@@ -314,5 +314,5 @@ incus exec my-proxy -- chown -R www-data:www-data /var/cache/nginx
 
 ## See Also
 
-- [Traefik Appliance](../traefik/) - Modern reverse proxy with automatic HTTPS
-- [Caddy Appliance](../caddy/) - Web server with automatic HTTPS
+- [Nginx Documentation](https://nginx.org/en/docs/)
+- [Incus Documentation](https://linuxcontainers.org/incus/docs/main/)

--- a/appliances/nginx/appliance.yaml
+++ b/appliances/nginx/appliance.yaml
@@ -66,7 +66,7 @@ tags:
   - proxy
   - reverse-proxy
 
-# Related appliances
-see_also:
-  - traefik
-  - caddy
+# Related appliances (uncomment when available)
+# see_also:
+#   - traefik
+#   - caddy


### PR DESCRIPTION
## Summary
- Removes references to traefik and caddy appliances that don't exist yet

### Changes
- **appliance.yaml**: Comment out `see_also` section until these appliances are created
- **README.md**: Replace broken appliance links with useful external documentation links (Nginx docs, Incus docs)

## Test plan
- [x] Verify no broken links remain in nginx appliance docs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)