### PR TITLE
Add security scanning to CI pipeline

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  security-events: write
 
 jobs:
   generate-matrix:
@@ -150,6 +151,54 @@ jobs:
         run: |
           # Build using the new Incus-based build script
           ./bin/build-appliance-incus.sh ${{ matrix.appliance }} ${{ matrix.arch }}
+
+      - name: Extract rootfs for security scanning
+        id: extract
+        run: |
+          BUILD_DIR=".build/${{ matrix.appliance }}/${{ matrix.arch }}"
+          SCAN_DIR="${BUILD_DIR}/rootfs-scan"
+          mkdir -p "${SCAN_DIR}"
+
+          # Extract squashfs for scanning
+          sudo unsquashfs -d "${SCAN_DIR}/rootfs" "${BUILD_DIR}/rootfs.squashfs"
+          sudo chown -R $(id -u):$(id -g) "${SCAN_DIR}"
+
+          echo "scan_dir=${SCAN_DIR}/rootfs" >> $GITHUB_OUTPUT
+
+      - name: Scan rootfs for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'rootfs'
+          scan-ref: ${{ steps.extract.outputs.scan_dir }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+
+      - name: Fail on critical vulnerabilities
+        run: |
+          # Install Trivy using the official install script (works on any Linux)
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+
+          # Check for critical vulnerabilities - fail the build if found
+          trivy rootfs --exit-code 1 --severity CRITICAL --ignore-unfixed --ignorefile .trivyignore ${{ steps.extract.outputs.scan_dir }} || {
+            echo "::error::Critical vulnerabilities found in ${{ matrix.appliance }} (${{ matrix.arch }})"
+            exit 1
+          }
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: '${{ matrix.appliance }}-${{ matrix.arch }}'
+
+      - name: Cleanup scan directory
+        if: always()
+        run: |
+          BUILD_DIR=".build/${{ matrix.appliance }}/${{ matrix.arch }}"
+          sudo rm -rf "${BUILD_DIR}/rootfs-scan"
 
       - name: Prepare image files for release
         id: metadata

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Trivy Ignore File
+# Add CVE IDs here to suppress false positives or accepted risks
+# Format: CVE-YYYY-NNNNN
+#
+# Before adding a CVE here, document:
+# 1. Why this is a false positive OR
+# 2. Why the risk is acceptable
+# 3. When to revisit (if applicable)
+#
+# Example:
+# CVE-2023-12345  # Not applicable: feature not used in our configuration
+
+# Currently no CVEs are ignored

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,21 @@ Before submitting, verify:
 - [ ] Documentation is clear and accurate
 - [ ] No security issues (shellcheck, yamllint)
 
+### Security Scanning
+
+All appliance images are scanned for vulnerabilities using [Trivy](https://trivy.dev/) during CI:
+
+- **Critical vulnerabilities** — Will fail the build and must be fixed
+- **High/Medium vulnerabilities** — Reported in GitHub Security tab
+- **False positives** — Can be added to `.trivyignore` with justification
+
+If your build fails due to security issues:
+
+1. Check the Trivy output in the CI logs
+2. Update packages to patched versions if available
+3. If it's a false positive, add to `.trivyignore` with a comment explaining why
+4. Document any accepted risks in the PR description
+
 ## Pull Request Process
 
 This project uses **GitHub Flow** with squash merging. All changes must go through pull requests.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -381,6 +381,30 @@ Generated and managed by `incus-simplestreams`:
    - Minimal attack surface
    - Services run as non-root users
 
+### Vulnerability Scanning
+
+All appliance images are automatically scanned for security vulnerabilities before publishing:
+
+1. **Trivy Scanner**
+   - Scans rootfs for known CVEs
+   - Checks OS packages (Debian/apt)
+   - Detects vulnerabilities in system libraries
+
+2. **Build Pipeline Integration**
+   - Scanning runs after each build
+   - Results uploaded to GitHub Security tab
+   - Critical vulnerabilities fail the build
+
+3. **Severity Levels**
+   - **CRITICAL** — Build fails, must be fixed
+   - **HIGH/MEDIUM** — Reported, visible in Security tab
+   - **LOW** — Tracked but not blocking
+
+4. **Managing False Positives**
+   - Use `.trivyignore` file to suppress known false positives
+   - Document reason for each suppression
+   - Review periodically for updates
+
 ### Registry Security
 
 1. **Transport**


### PR DESCRIPTION
## Summary

Integrates Trivy vulnerability scanner into the build workflow to scan all appliance images before publishing. This ensures known CVEs in base images or packages are detected before users deploy containers.

- Add Trivy scanning steps after build in CI workflow
- Fail builds on critical vulnerabilities
- Upload scan results to GitHub Security tab (SARIF format)
- Add `.trivyignore` file for managing false positives
- Document security scanning in architecture.md and CONTRIBUTING.md

## How It Works

1. After each appliance image is built, the rootfs is extracted from squashfs
2. Trivy scans the rootfs for known vulnerabilities
3. Results are uploaded to GitHub Security tab in SARIF format
4. If critical vulnerabilities are found, the build fails
5. High/Medium vulnerabilities are reported but don't fail the build

## Acceptance Criteria from #13

- [x] All images scanned before publishing
- [x] Critical vulnerabilities fail the build
- [x] Scan results visible in GitHub Security tab
- [x] Documentation updated with security scanning info
- [x] Add `.trivyignore` for false positives or accepted risks

Closes #13

## Test Plan

- [ ] Verify workflow syntax is valid
- [ ] Trigger a build and confirm Trivy scanning runs
- [ ] Check GitHub Security tab shows scan results
- [ ] Verify builds fail when critical vulnerabilities are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)